### PR TITLE
Berkchef 3, Chef 12, Postgres 9.3

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,4 @@
-site :opscode
+source "https://supermarket.chef.io"
 
-cookbook 'wercker-postgresql', git: 'https://github.com/wercker/wercker-postgresql-cookbook.git'
-
-cookbook 'apt', '1.8.2'
-cookbook 'postgresql', '3.0.2'
+cookbook 'apt', '2.6.1'
+cookbook 'postgresql', '3.4.14'

--- a/solo.json
+++ b/solo.json
@@ -6,19 +6,19 @@
     "password": {
       "postgres": "wercker"
     },
-    "version" : "9.2",
+    "version" : "9.3",
     "enable_pgdg_apt" : true,
-    "dir" : "/etc/postgresql/9.2/main",
-    "server" : { "packages": ["postgresql-9.2"] },
+    "dir" : "/etc/postgresql/9.3/main",
+    "server" : { "packages": ["postgresql-9.3"] },
     "ssl" : false,
     "config" : { 
       "listen_addresses" : "*",
       "ssl_key_file" : "/etc/ssl/private/ssl-cert-snakeoil.key",
       "ssl_cert_file" : "/etc/ssl/certs/ssl-cert-snakeoil.pem",
-      "data_directory" : "/var/lib/postgresql/9.2/main",
-      "hba_file" : "/etc/postgresql/9.2/main/pg_hba.conf",
-      "ident_file" : "/etc/postgresql/9.2/main/pg_ident.conf",
-      "external_pid_file" : "/var/run/postgresql/9.2-main.pid"
+      "data_directory" : "/var/lib/postgresql/9.3/main",
+      "hba_file" : "/etc/postgresql/9.3/main/pg_hba.conf",
+      "ident_file" : "/etc/postgresql/9.3/main/pg_ident.conf",
+      "external_pid_file" : "/var/run/postgresql/9.3-main.pid"
       },
     "pg_hba" : [
       { "comment" : "# wercker: allow all", 

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,22 +1,32 @@
-name: postgresql9.2
-version: 0.0.7
+name: postgresql9.3
+version: 0.0.7-usermind-9.3-1
 inherits: wercker/ubuntu12.04-chef10.18.2@0.0.8
 type: service
 platform: ubuntu@12.04
-description: postgresql 9.2
+description: postgresql 9.3
 keywords:
   - postgresql
-  - postgresql9.2
+  - postgresql9.3
 packages:
-  - postgresql@9.2
+  - postgresql@9.3
 script: |
   # Remove previous postgres files
   rm -rf  /etc/postgresql
   rm -rf /etc/postgresql-common
   rm -rf /var/lib/postgresql
 
+  # From wercker box-ubuntu12.04-chef10.18.2, updated for chef 12
+  sudo apt-get update
+  sudo apt-get install -yq wget curl
+  export CHEF_DEB=chef_12.0.3-1_amd64.deb
+  cd
+  wget https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/$CHEF_DEB
+  sudo dpkg -i $CHEF_DEB
+  chef-solo -v
+  rm $CHEF_DEB
+
   sudo chef-solo -c $WERCKER_SOURCE_DIR/solo.rb -j $WERCKER_SOURCE_DIR/solo.json -l debug
-  sudo apt-get install  postgresql-contrib-9.2
+  sudo apt-get install  postgresql-contrib-9.3
   export PGPASSWORD=wercker
   echo "CREATE DATABASE werckerdb1;" | psql -U postgres -h 127.0.0.1
   

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,8 +1,8 @@
-box : wercker/ubuntu12.04-ruby1.9.3-berkshelf1
+box : userminddeployer/ubuntu12.04-ruby1.9.3-berkshelf3
 build :
   steps :
     - script:
         name : install cookbooks
         code : |
           cd $WERCKER_ROOT
-          berks install -p cookbooks
+          berks vendor cookbooks


### PR DESCRIPTION
Wercker doesn't have a service box for Postgres 9.3, only 9.2, which doesn't have JSON support. Forked here to update to 9.3.

Getting this to build required updating Berkshelf, which in turn required updating Chef. The Berkshelf update was done in a separate box, the Chef update was done here, but should probably get an updated box as time permits.

Tested and validated, merging TBR.